### PR TITLE
Change PartitionKey to Guid in RSSNotificationHistory Table

### DIFF
--- a/docs/dynamodb.md
+++ b/docs/dynamodb.md
@@ -12,7 +12,7 @@ RSS 側の記事を識別するキー(記事名が現実的か)を特定し、�
 テーブル名: NotificationHistory
 | Attribute | Type | Key | Example |
 | :---------- | :----- | :-- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Title | String | PK | Building a Visual Quality Control Solution with Amazon Lookout for Vision and Advanced Video Preprocessing |
+| Guid | String | PK | 123e4567-e89b-12d3-a456-426614174000 |
 | Type | String | | "blogs" or "announcements" |
 | Link | String | | https://aws.amazon.com/jp/blogs/apn/building-a-visual-quality-control-solution-with-amazon-lookout-for-vision-and-advanced-video-preprocessing/ |
 | Description | String | | Conveyor belts are an essential material handling tool for various industrial processes, but high throughput rates make it difficult for operators to detect defective products and remove them from the production line. Learn how Grid Dynamics built an advanced video preprocessor and integrated it with Amazon Lookout for Vision, using a food processing use case as an example. Amazon Lookout for Vision is an AutoML service for detecting anomalies in images. |

--- a/lib/rss-feed-translater-stack.ts
+++ b/lib/rss-feed-translater-stack.ts
@@ -64,7 +64,7 @@ export class RssFeedTranslaterStack extends Stack {
       `notificationHistory`,
       {
         partitionKey: {
-          name: "Title",
+          name: "Guid",
           type: dynamodb.AttributeType.STRING,
         },
         tableName: "RSSNotificationHistory",

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -12,12 +12,12 @@ const client = new DynamoDBClient({
 });
 const ddbClient = DynamoDBDocumentClient.from(client);
 
-export const fetchHistoryByTitle = async (title: string) => {
+export const fetchHistoryByGuid = async (guid: string) => {
   const queryParams: QueryCommandInput = {
     TableName: "RSSNotificationHistory",
     ConsistentRead: false,
-    KeyConditionExpression: "Title = :value",
-    ExpressionAttributeValues: { ":value": title },
+    KeyConditionExpression: "Guid = :value",
+    ExpressionAttributeValues: { ":value": guid },
   };
 
   try {
@@ -30,7 +30,7 @@ export const fetchHistoryByTitle = async (title: string) => {
 };
 
 type PutHistoryInput = {
-  Title: string;
+  Guid: string;
   Type: string;
   Link: string;
   Description: string;


### PR DESCRIPTION
Related to #2

This pull request updates the partition key in the `RSSNotificationHistory` table from `Title` to `Guid` and adjusts related processes to use the new key.

- **DynamoDB Table Update**: Changes the partition key in the `RSSNotificationHistory` table definition from `Title` to `Guid` in `lib/rss-feed-translater-stack.ts`.
- **Documentation Update**: Updates `docs/dynamodb.md` to reflect the change in the partition key from `Title` to `Guid`, including updating the example to use a `Guid` value.
- **Code Adjustments**:
  - Modifies `src/lib/history.ts` to replace `fetchHistoryByTitle` with `fetchHistoryByGuid` and updates the `putHistory` function to include and use `Guid` as the key.
  - Updates `src/index.ts` to construct item objects with a `Guid` property derived from the RSS feed item and adjusts calls to the updated `fetchHistoryByGuid` function.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joe-king-sh/rss-feed-translater/issues/2?shareId=e7f148d2-8076-42fd-a5ae-a955b8f6f0d2).